### PR TITLE
Fix: Include count on blue dns record

### DIFF
--- a/route53-record.tf
+++ b/route53-record.tf
@@ -13,6 +13,8 @@ resource "aws_route53_record" "hostname" {
 }
 
 resource "aws_route53_record" "hostname_blue" {
+  count   = var.hostname_create ? 1 : 0
+  
   zone_id = data.aws_route53_zone.selected.zone_id
   name    = var.hostname_blue
   type    = "CNAME"


### PR DESCRIPTION
Include count on create blue dns record.
When the variable hostname_create is set to false is juste reflect on the main subdomain.