### PR TITLE
removing blue DNS variable

### DIFF
--- a/_variables.tf
+++ b/_variables.tf
@@ -10,10 +10,6 @@ variable "hostname" {
   description = "Hostname to create DNS record for this app"
 }
 
-variable "hostname_blue" {
-  description = "Blue hostname for testing the app"
-}
-
 variable "hostname_create" {
   description = "Create hostname in the hosted zone passed?"
   default     = true
@@ -37,7 +33,7 @@ variable "alb_dns_name" {
 }
 
 variable "certificate_arn" {
-  description = "Certificate for this app to use in CloudFront (US), must cover `hostname` and (ideally) `hostname_blue` passed."
+  description = "Certificate for this app to use in CloudFront (US), must cover `hostname`."
 }
 
 variable "cloudfront_web_acl_id" {

--- a/cloudfront.tf
+++ b/cloudfront.tf
@@ -2,7 +2,7 @@ resource "aws_cloudfront_distribution" "default" {
   enabled             = true
   is_ipv6_enabled     = true
   comment             = var.hostname
-  aliases             = concat(list(var.hostname), compact(split(",", var.hostname_redirects)), list(var.hostname_blue))
+  aliases             = concat(list(var.hostname), compact(split(",", var.hostname_redirects)))
   price_class         = "PriceClass_All"
   wait_for_deployment = false
 

--- a/route53-record.tf
+++ b/route53-record.tf
@@ -12,12 +12,3 @@ resource "aws_route53_record" "hostname" {
   records = list(element(aws_cloudfront_distribution.default.*.domain_name, 0))
 }
 
-resource "aws_route53_record" "hostname_blue" {
-  count = var.hostname_create ? 1 : 0
-
-  zone_id = data.aws_route53_zone.selected.zone_id
-  name    = var.hostname_blue
-  type    = "CNAME"
-  ttl     = "300"
-  records = list(element(aws_cloudfront_distribution.default.*.domain_name, 0))
-}


### PR DESCRIPTION
This brench is part of the task originated from https://trello.com/c/muVbuE1h

I have removed variables for blue DNS name since a new test listener on port 8443 was created, allowing new environment to be tested using the new listener